### PR TITLE
Symbolicate error reports locally by default

### DIFF
--- a/Backtrace-PLCrashReporter.podspec
+++ b/Backtrace-PLCrashReporter.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Backtrace-PLCrashReporter"
-  s.version      = "1.5.3"
+  s.version      = "1.5.4"
   s.summary      = "Reliable, open-source crash reporting for iOS, tvOS and macOS."
   s.description      = <<-DESC
                       Plausible CrashReporter provides an in-process crash reporting

--- a/Sources/PLCrashReporterConfig.m
+++ b/Sources/PLCrashReporterConfig.m
@@ -51,7 +51,7 @@
  * is appropriate for use in release builds.
  */
 - (instancetype) init {
-    return [self initWithSignalHandlerType: PLCrashReporterSignalHandlerTypeBSD symbolicationStrategy: PLCrashReporterSymbolicationStrategyNone];
+    return [self initWithSignalHandlerType: PLCrashReporterSignalHandlerTypeBSD symbolicationStrategy: PLCrashReporterSymbolicationStrategyAll];
 }
 
 /**


### PR DESCRIPTION
Changed the error reports symbolication strategy to symbolicate all the error reports locally by default.